### PR TITLE
docs: Add `go install` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ just require:
 
 ```bash
 $ go get github.com/sqlitebrowser/dio
+$ go install github.com/sqlitebrowser/dio
 ```
 
 ## Getting Started


### PR DESCRIPTION
See https://go.dev/doc/go-get-install-deprecation