### PR TITLE
Add CI testing for dio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Install NodeJS 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    # Build and start the DBHub.io server daemons
+    - name: Checkout the DBHub.io source code
+      uses: actions/checkout@v4
+      with:
+        repository: 'sqlitebrowser/dbhub.io'
+        path: daemons
+
+    - name: Build the DBHub.io daemons
+      run: cd daemons; yarn docker:build
+
+    - name: Update the daemon config file
+      run: cd daemons; sed -i 's/bind_address = ":9443"/bind_address = "0.0.0.0:9443"/' docker/config.toml
+
+    - name: Start the DBHub.io daemons
+      run: cd daemons; docker run -itd --rm --name dbhub-build --net host dbhub-build:latest && sleep 5
+
+    # Build and test dio
+    - name: Checkout dio source code
+      uses: actions/checkout@v4
+      with:
+        path: main
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Build dio
+      run: cd main; go build -v
+
+    - name: Test dio
+      run: cd main; IS_TESTING=yes go test ./cmd -v -check.v

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,11 @@ func init() {
 	// Add support for pretty printing numbers
 	numFormat = message.NewPrinter(message.MatchLanguage("en"))
 
+	// When run from go test we skip this, as we generate a temporary config file in the test suite setup
+	if os.Getenv("IS_TESTING") == "yes" {
+		return
+	}
+
 	// Add the global environment variables
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		fmt.Sprintf("config file (default is %s)", filepath.Join("$HOME", ".dio", "config.toml")))


### PR DESCRIPTION
This PR adds automatic CI testing to the dio repo.

As part of this, it removes the old mock server code that was previously used for testing.

Instead, it builds a fresh DBHub.io development docker container (from latest dbhub.io master branch) and tests against that.

This should give much more accurate pass/fail results compared to using a mocked server.